### PR TITLE
CBIIT user ID requirements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 *.rdf
 *.rst
-*.sh
 *.sublime-*
 .*.cfg
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,73 @@
 # Basis
 # -----
 #
-# Based on Plone (Debian) 5.1.5
-# This provides a ``EXPOSE 8080``, some ``ENV``, and an ``ENTRYPOINT`` and ``CMD``.
-# It also specifies ``VOLUME /data``.
-FROM plone/plone:5.1.5
+# Used to be based on Plone (Debian) 5.1.5, except that it specifies ``VOLUME /data``
+# and CBIIT demands we run the internal container with username "edrn" with user ID
+# 26013. Normally we would just ``adduser`` and ``chown`` except thanks to the
+# ``VOLUME /data`` nothing we ``chwon`` under ``/data`` takes effect and there's no
+# way to undo a basis image's ``VOLUME`` (see this_). So now we have to reproduce
+# every damn thing the ``plone/plone:5.1.5`` image does.
+#
+# That's what follows below:
 
+FROM python:2.7-slim-stretch
 
+ENV PIP=9.0.3 \
+    ZC_BUILDOUT=2.11.4 \
+    SETUPTOOLS=39.1.0 \
+    WHEEL=0.31.1 \
+    PLONE_MAJOR=5.1 \
+    PLONE_VERSION=5.1.5 \
+    PLONE_MD5=8ed5ff27fab67b1b510a1ce0ee2dd655
+
+LABEL plone=$PLONE_VERSION \
+    os="debian" \
+    os.version="9" \
+    name="Plone 5.1" \
+    description="Plone image, based on Unified Installer" \
+    maintainer="Plone Community"
+
+RUN useradd --system -m -d /plone -U -u 26013 edrn \
+ && mkdir -p /plone/instance/ /data/filestorage /data/blobstorage
+
+COPY buildout.cfg /plone/instance/
+
+RUN buildDeps="dpkg-dev gcc libbz2-dev libc6-dev libjpeg62-turbo-dev libopenjp2-7-dev libpcre3-dev libssl-dev libtiff5-dev libxml2-dev libxslt1-dev wget zlib1g-dev" \
+ && runDeps="gosu libjpeg62 libopenjp2-7 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv" \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends $buildDeps \
+ && wget -O Plone.tgz https://launchpad.net/plone/$PLONE_MAJOR/$PLONE_VERSION/+download/Plone-$PLONE_VERSION-UnifiedInstaller.tgz \
+ && echo "$PLONE_MD5 Plone.tgz" | md5sum -c - \
+ && tar -xzf Plone.tgz \
+ && cp -rv ./Plone-$PLONE_VERSION-UnifiedInstaller/base_skeleton/* /plone/instance/ \
+ && cp -v ./Plone-$PLONE_VERSION-UnifiedInstaller/buildout_templates/buildout.cfg /plone/instance/buildout-base.cfg \
+ && pip install pip==$PIP setuptools==$SETUPTOOLS zc.buildout==$ZC_BUILDOUT wheel==$WHEEL \
+ && cd /plone/instance \
+ && buildout \
+ && ln -s /data/filestorage/ /plone/instance/var/filestorage \
+ && ln -s /data/blobstorage /plone/instance/var/blobstorage \
+ && chown -R edrn:edrn /plone /data \
+ && rm -rf /Plone* \
+ && apt-get purge -y --auto-remove $buildDeps \
+ && apt-get install -y --no-install-recommends $runDeps \
+ && rm -rf /var/lib/apt/lists/* \
+ && rm -rf /plone/buildout-cache/downloads/*
+
+VOLUME /data
+
+COPY docker-initialize.py docker-entrypoint.sh /
+
+EXPOSE 8080
+WORKDIR /plone/instance
+
+HEALTHCHECK --interval=1m --timeout=5s --start-period=1m \
+  CMD nc -z -w5 127.0.0.1 8080 || exit 1
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["start"]
+
+# And now we resume our friendly standard Dockerfile:
+#
 # Dependecies
 # -----------
 #
@@ -28,9 +89,9 @@ RUN apt-get update \
 # Prepare the file structure of the image with our custom Buildout config
 # named ``docker.cfg``, its inclusions in ``etc``, the custom Plone source
 # in ``src``.
-COPY --chown=plone:plone docker.cfg /plone/instance
-COPY --chown=plone:plone etc /plone/instance/etc
-COPY --chown=plone:plone src /plone/instance/src
+COPY --chown=edrn:edrn docker.cfg /plone/instance
+COPY --chown=edrn:edrn etc /plone/instance/etc
+COPY --chown=edrn:edrn src /plone/instance/src
 
 
 # Build
@@ -40,7 +101,7 @@ COPY --chown=plone:plone src /plone/instance/src
 # and buildout detritus then running Buildout on the ``docker.cfg``.
 RUN find /plone/instance/src -name '*.py[co]' -exec rm -f '{}' + \
     && rm -rf /plone/instance/src/*/{var,bin,develop-eggs,parts} \
-    && gosu plone buildout -c docker.cfg
+    && gosu edrn buildout -c docker.cfg
 
 # TOD: do we need utf-8 sys.defaultencoding workaround??
 

--- a/GNU-LICENSE.txt
+++ b/GNU-LICENSE.txt
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc., <http://fsf.org/>
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    {description}
+    Copyright (C) {year}  {fullname}
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  {signature of Ty Coon}, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -200,3 +200,4 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+

--- a/README.md
+++ b/README.md
@@ -44,3 +44,5 @@ To contact the team as a whole, [email the Informatics Center](mailto:ic-portal@
 ## 📃 License
 
 The project is licensed under the [Apache version 2](LICENSE.txt) license.
+
+Note that this package includes software from [Plone Docker](https://github.com/plone/plone.docker) licensed under the [GNU Public License version 2](GNU-LICENSE.txt). The source code fot this software is included in the files [Dockerfile](Dockerfile), [docker-entrypoint.sh](docker-entrypoint.sh), [docker-initialize.py](docker-initialize.py), and [buildout.cfg](buildout.cfg).

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,0 +1,63 @@
+[buildout]
+extends =
+  buildout-base.cfg
+
+extensions =
+  buildout.wheel
+
+effective-user = edrn
+buildout-user = edrn
+var-dir=/data
+user=admin:admin
+parts +=
+  zeo
+  mrbob
+
+[client1]
+recipe =
+
+[zeo]
+<= zeoserver_base
+recipe = plone.recipe.zeoserver
+zeo-address = 8080
+
+# Requires gcc, thus install it on image build
+[mrbob]
+recipe = zc.recipe.egg
+eggs =
+  mr.bob
+  bobtemplates.plone
+
+[versions]
+setuptools =
+zc.buildout =
+
+# The following part definition lists the versions picked:
+Pillow = 5.3.0
+buildout.wheel = 0.2.0
+plone.recipe.command = 1.1
+plone.recipe.precompiler = 0.6
+collective.recipe.backup = 4.0.1
+Unidecode = 0.04.16
+
+MarkupSafe = 1.0
+bobtemplates.plone = 3.5.1
+mr.bob = 0.1.2
+regex = 2018.8.29
+
+# Required by:
+# bobtemplates.plone==3.5.1
+case-conversion = 2.1.0
+
+# Required by:
+# bobtemplates.plone==3.5.1
+python-slugify = 1.2.6
+
+Products.DocFinderTab = 1.0.5
+collective.checkdocs = 0.2
+zest.pocompile = 1.4
+
+# Required by:
+# bobtemplates.plone==3.5.1
+# zest.releaser==6.15.0
+colorama = 0.4.0

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+
+COMMANDS="debug help logtail show stop adduser fg kill quit run wait console foreground logreopen reload shell status"
+START="start restart zeoserver"
+CMD="bin/instance"
+
+gosu edrn python /docker-initialize.py
+
+if [ -e "custom.cfg" ]; then
+  if [ ! -e "bin/develop" ]; then
+    gosu edrn buildout -c custom.cfg
+    gosu edrn python /docker-initialize.py
+  fi
+fi
+
+if [[ "$1" == "zeo"* ]]; then
+  CMD="bin/$1"
+fi
+
+if [ -z "$HEALTH_CHECK_TIMEOUT" ]; then
+  HEALTH_CHECK_TIMEOUT=1
+fi
+
+if [ -z "$HEALTH_CHECK_INTERVAL" ]; then
+  HEALTH_CHECK_INTERVAL=1
+fi
+
+if [[ $START == *"$1"* ]]; then
+  _stop() {
+    gosu edrn $CMD stop
+    kill -TERM $child 2>/dev/null
+  }
+
+  trap _stop SIGTERM SIGINT
+  gosu edrn $CMD start
+  gosu edrn $CMD logtail &
+  child=$!
+
+  pid=`$CMD status | sed 's/[^0-9]*//g'`
+  if [ ! -z "$pid" ]; then
+    echo "Application running on pid=$pid"
+    sleep "$HEALTH_CHECK_TIMEOUT"
+    while kill -0 "$pid" 2> /dev/null; do
+      sleep "$HEALTH_CHECK_INTERVAL"
+    done
+  else
+    echo "Application didn't start normally. Shutting down!"
+    _stop
+  fi
+else
+  if [[ $COMMANDS == *"$1"* ]]; then
+    exec gosu edrn bin/instance "$@"
+  fi
+  exec "$@"
+fi

--- a/docker-initialize.py
+++ b/docker-initialize.py
@@ -1,0 +1,178 @@
+#!/usr/local/bin/python
+
+import re
+import os
+import warnings
+warnings.simplefilter('always', DeprecationWarning)
+
+class Environment(object):
+    """ Configure container via environment variables
+    """
+    def __init__(self, env=os.environ,
+                 zope_conf="/plone/instance/parts/instance/etc/zope.conf",
+                 custom_conf="/plone/instance/custom.cfg",
+                 zeopack_conf="/plone/instance/bin/zeopack",
+                 zeoserver_conf="/plone/instance/parts/zeoserver/etc/zeo.conf"
+                 ):
+        self.env = env
+        self.zope_conf = zope_conf
+        self.custom_conf = custom_conf
+        self.zeopack_conf = zeopack_conf
+        self.zeoserver_conf = zeoserver_conf
+
+    def zeoclient(self):
+        """ ZEO Client
+        """
+        server = self.env.get("ZEO_ADDRESS", None)
+        if not server:
+            return
+
+        config = ""
+        with open(self.zope_conf, "r") as cfile:
+            config = cfile.read()
+
+        # Already initialized
+        if "<blobstorage>" not in config:
+            return
+
+        read_only = self.env.get("ZEO_READ_ONLY", "false")
+        zeo_ro_fallback = self.env.get("ZEO_CLIENT_READ_ONLY_FALLBACK", "false")
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
+        zeo_storage=self.env.get("ZEO_STORAGE", "1")
+        zeo_client_cache_size=self.env.get("ZEO_CLIENT_CACHE_SIZE", "128MB")
+        zeo_conf = ZEO_TEMPLATE.format(
+            zeo_address=server,
+            read_only=read_only,
+            zeo_client_read_only_fallback=zeo_ro_fallback,
+            shared_blob_dir=shared_blob_dir,
+            zeo_storage=zeo_storage,
+            zeo_client_cache_size=zeo_client_cache_size
+        )
+
+        pattern = re.compile(r"<blobstorage>.+</blobstorage>", re.DOTALL)
+        config = re.sub(pattern, zeo_conf, config)
+
+        with open(self.zope_conf, "w") as cfile:
+            cfile.write(config)
+
+    def zeopack(self):
+        """ ZEO Pack
+        """
+        server = self.env.get("ZEO_ADDRESS", None)
+        if not server:
+            return
+
+        if ":" in server:
+            host, port = server.split(":")
+        else:
+            host, port = (server, "8100")
+
+        with open(self.zeopack_conf, 'r') as cfile:
+            text = cfile.read()
+            text = text.replace('address = "8100"', 'address = "%s"' % server)
+            text = text.replace('host = "127.0.0.1"', 'host = "%s"' % host)
+            text = text.replace('port = "8100"', 'port = "%s"' % port)
+
+        with open(self.zeopack_conf, 'w') as cfile:
+            cfile.write(text)
+
+    def zeoserver(self):
+        """ ZEO Server
+        """
+        pack_keep_old = self.env.get("ZEO_PACK_KEEP_OLD", '')
+        if pack_keep_old.lower() in ("false", "no", "0", "n", "f"):
+            with open(self.zeoserver_conf, 'r') as cfile:
+                text = cfile.read()
+                if 'pack-keep-old' not in text:
+                    text = text.replace(
+                        '</filestorage>',
+                        '  pack-keep-old false\n</filestorage>'
+                    )
+
+            with open(self.zeoserver_conf, 'w') as cfile:
+                cfile.write(text)
+
+    def buildout(self):
+        """ Buildout from environment variables
+        """
+        # Already configured
+        if os.path.exists(self.custom_conf):
+            return
+
+        eggs = self.env.get("PLONE_ADDONS",
+               self.env.get("ADDONS", "")).strip().split()
+        if not eggs:
+            eggs = self.env.get("BUILDOUT_EGGS", "").strip().split()
+            if eggs:
+                warnings.warn(
+                    "BUILDOUT_EGGS is deprecated. Please use "
+                    "PLONE_ADDONS instead !!!", DeprecationWarning)
+
+        zcml = self.env.get("PLONE_ZCML",
+               self.env.get("ZCML", "")).strip().split()
+        if not zcml:
+            zcml = self.env.get("BUILDOUT_ZCML", "").strip().split()
+            if zcml:
+                warnings.warn(
+                    "BUILDOUT_ZCML is deprecated. Please use "
+                    "PLONE_ZCML instead !!!", DeprecationWarning)
+
+        develop = self.env.get("PLONE_DEVELOP",
+                  self.env.get("DEVELOP", "")).strip().split()
+        if not develop:
+            develop = self.env.get("BUILDOUT_DEVELOP", "").strip().split()
+            if develop:
+                warnings.warn(
+                    "BUILDOUT_DEVELOP is deprecated. Please use "
+                    "PLONE_DEVELOP instead !!!", DeprecationWarning)
+
+        if not (eggs or zcml or develop):
+            return
+
+        buildout = BUILDOUT_TEMPLATE.format(
+            eggs="\n\t".join(eggs),
+            zcml="\n\t".join(zcml),
+            develop="\n\t".join(develop)
+        )
+
+        with open(self.custom_conf, 'w') as cfile:
+            cfile.write(buildout)
+
+    def setup(self, **kwargs):
+        self.buildout()
+        self.zeoclient()
+        self.zeopack()
+        self.zeoserver()
+
+    __call__ = setup
+
+ZEO_TEMPLATE = """
+    <zeoclient>
+      read-only {read_only}
+      read-only-fallback {zeo_client_read_only_fallback}
+      blob-dir /data/blobstorage
+      shared-blob-dir {shared_blob_dir}
+      server {zeo_address}
+      storage {zeo_storage}
+      name zeostorage
+      var /plone/instance/parts/instance/var
+      cache-size {zeo_client_cache_size}
+    </zeoclient>
+""".strip()
+
+BUILDOUT_TEMPLATE = """
+[buildout]
+extends = develop.cfg
+develop += {develop}
+eggs += {eggs}
+zcml += {zcml}
+"""
+
+def initialize():
+    """ Configure Plone instance as ZEO Client
+    """
+    environment = Environment()
+    environment.setup()
+
+if __name__ == "__main__":
+    initialize()


### PR DESCRIPTION
Because

1. CBIIT requires us to use user name "edrn" with user ID 26013 in the container and
2. Docker doesn't provide a way to undo a "VOLUME" command in basis images
3. The Plone base image creates the user "plone" with user ID 500
4. And also sets the ownership of files & directories in `/data` to "plone"

we have to re-do everything Plone does because, even though we can add and even run things as "edrn" in a derived image, the "VOLUME" command means nothing we do to `/data` takes effect.